### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Kule Lazy 3
 
 版本：3.1.161014
 
+[![CDNJS](https://img.shields.io/cdnjs/v/kule.lazy.svg)](https://cdnjs.com/libraries/kule.lazy)
 [![Join the chat at https://gitter.im/keicheng/kule.lazy](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/keicheng/kule.lazy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 使用說明請看：http://www.kule.tw/doc.html


### PR DESCRIPTION
This will add a badge that shows the lib version on CDNJS and link to its page on CDNJS!
